### PR TITLE
correct jHiccup.jar lookup

### DIFF
--- a/jHiccupLogProcessor
+++ b/jHiccupLogProcessor
@@ -43,15 +43,33 @@ JHICCUP_Version=2.0.4
 # PARSED_SCRIPT=`readlink -f $0`
 # INSTALLED_PATH=`dirname $PARSED_SCRIPT`
 # But readlink -f doesn't work the same everywhere (e.g. Mac OS). We use this instead:
-function readlink_f () { _=`pwd`; cd `dirname $1` && echo `pwd` && cd $_; }
-INSTALLED_PATH=$(readlink_f $0)
+function readlink_f() {
+  local _dir _path="$1"
+  while [ -L "$_path" ]; do
+    _dir=$(dirname "$_path")
+    _path=$(readlink "$_path")
+    [ -n "${_path##/*}" ] && _path="${_dir}/${_path}"
+  done
+  _dir=$(cd "$(dirname "$_path")"; pwd -P)
+  echo "${_dir}/$(basename "$_path")"
+}
+INSTALLED_PATH=$(dirname "$(readlink_f "$0")")
 
 # Check if running from unpacked distribution archive by assuming jHiccup.jar
 # in the same directory as this script. If not, try to search in target/ directory
 # (running from the source repository build).
-JHICCUP_JAR_FILE=$INSTALLED_PATH/jHiccup.jar
-if [ ! -f $JHICCUP_JAR_FILE ] ; then
-  JHICCUP_JAR_FILE=$INSTALLED_PATH/target/jHiccup.jar
+JHICCUP_JAR_FILE="$INSTALLED_PATH/jHiccup.jar"
+if [ ! -f "$JHICCUP_JAR_FILE" ] ; then
+  JHICCUP_JAR_FILE="$INSTALLED_PATH/target/jHiccup.jar"
+fi
+
+if [ ! -f "$JHICCUP_JAR_FILE" ] ; then
+  JHICCUP_JAR_FILE="$INSTALLED_PATH/../jHiccup.jar"
+fi
+
+if [ ! -f "$JHICCUP_JAR_FILE" ] ; then
+    echo "For this command to run, jHiccup.jar must be available in '${INSTALLED_PATH%/bin*}'."
+    exit 1
 fi
 
 JAVA_BIN=`which java`


### PR DESCRIPTION
When installed on macOS using Homebrew (`brew install jhiccup`), the path to `jHiccup.jar` couldn't be correctly resolved. There're two reasons:

1. the `readlink_f` function doesn't work because `/usr/local/bin/jHiccupLogProcessor` is a symbol link
2. the file `jHiccup.jar` isn't in the same dir as that of `jHiccupLogProcessor`